### PR TITLE
Pulsar update

### DIFF
--- a/src/core/io/Messaging/BasePulsarClient.js
+++ b/src/core/io/Messaging/BasePulsarClient.js
@@ -34,15 +34,7 @@ class BasePulsarClient {
       this.settings.tlsAllowInsecureConnection = false;
     }
 
-    if (this.settings.client_id !== undefined &&
-      this.settings.client_secret !== undefined &&
-      this.settings.issuer_url !== undefined &&
-      this.settings.grant_type !== undefined) {
-        this.oauthCredentials = true;
-      }
-
   }
-
   /**
    * Connects to the Pulsar server and returns a client
    * @returns New Pulsar Client
@@ -70,7 +62,7 @@ class BasePulsarClient {
   async connect() {
 
     // Create a Pulsar client
-    if(this.settings.oauthCredentials) {
+    if(this.hasOAuth()) {
       this.client = new Client({
         serviceUrl: this.settings.path,
         authentication: new AuthenticationOauth2({type: this.settings.grant_type, 
@@ -88,6 +80,13 @@ class BasePulsarClient {
 
   isTLSAllowInsecureConnection() {
     return this.settings.tlsAllowInsecureConnection === true || this.settings.tlsAllowInsecureConnection === 'true';
+  }
+  
+  hasOAuth(){
+    return this.settings.client_id !== undefined && 
+            this.settings.client_secret !== undefined &&
+            this.issuer_url !== undefined && 
+            this.issuer_url !== undefined;
   }
 }
 

--- a/src/core/io/Messaging/BasePulsarClient.js
+++ b/src/core/io/Messaging/BasePulsarClient.js
@@ -6,14 +6,14 @@
  * File Created: Wednesday, 20th July 2022 03:50 pm
  * Author: Billy Larsen (billy@siliconmtn.com)
  * -----
- * Last Modified: 
- * Modified By: 
+ * Last Modified: Wednesday, 9th August 2023 1:10pm
+ * Modified By: Alex Chung (alex.chung@siliconmtn.com)
  * -----
  * Copyright 2022, Silicon Mountain Technologies, Inc.
  */
 
 // Imports for this class
-import { Client, AuthenticationToken } from "pulsar-client";
+import { Client, AuthenticationOauth2 } from "pulsar-client";
 
 /**
  * Pulsar Message consumer
@@ -22,7 +22,7 @@ class BasePulsarClient {
   /**
    * Constructs the consumer with the appropriate host and port
    * @param {object} config Configuration for this app.  Must include the 
-   * host param (URL of the pulsar server) and the port of the server
+   * host param (URL of the pulsar server), the port of the server, client_id, client_secret, and issuer_url
    */
    constructor(config = {}) {
     this.settings = config;
@@ -34,7 +34,34 @@ class BasePulsarClient {
       this.settings.tlsAllowInsecureConnection = false;
     }
 
+    if (this.settings.client_id !== undefined &&
+      this.settings.client_secret !== undefined &&
+      this.settings.issuer_url !== undefined &&
+      this.settings.grant_type !== undefined) {
+        this.oauthCredentials = true;
+      }
+
   }
+
+  /**
+   * Connects to the Pulsar server and returns a client
+   * @returns New Pulsar Client
+   */
+  // async connect() {
+
+  //   // Create a Pulsar client
+  //   if(this.settings.jwtToken) {
+  //     this.client = new Client({
+  //       serviceUrl: this.settings.path,
+  //       authentication: new AuthenticationToken({token: this.settings.jwtToken}),
+  //       tlsAllowInsecureConnection: this.isTLSAllowInsecureConnection(),
+  //     });
+  //   } else {
+  //     this.client = new Client({
+  //       serviceUrl: this.settings.path
+  //     });
+  //   }
+  // }
 
   /**
    * Connects to the Pulsar server and returns a client
@@ -43,10 +70,13 @@ class BasePulsarClient {
   async connect() {
 
     // Create a Pulsar client
-    if(this.settings.jwtToken) {
+    if(this.settings.oauthCredentials) {
       this.client = new Client({
         serviceUrl: this.settings.path,
-        authentication: new AuthenticationToken({token: this.settings.jwtToken}),
+        authentication: new AuthenticationOauth2({type: this.settings.grant_type, 
+                                                  client_id: this.settings.client_id, 
+                                                  client_secret: this.settings.client_secret, 
+                                                  issuer_url: this.settings.issuer_url}),
         tlsAllowInsecureConnection: this.isTLSAllowInsecureConnection(),
       });
     } else {

--- a/src/core/io/Messaging/BasePulsarClient.test.js
+++ b/src/core/io/Messaging/BasePulsarClient.test.js
@@ -25,32 +25,59 @@ it("Doesn't Error on empty config", async () => {
     expect(pulsarClient.settings.tlsAllowInsecureConnection).toBe(config.tlsAllowInsecureConnection);
   });
 
+  // it("Configures a pulsarClient properly", async () => {
+  //   let config = {};
+  //   config.path = "pulsar://localhost:1000";
+  //   config.jwtToken = "1234abcd";
+  //   config.tlsAllowInsecureConnection = true;
+
+
+  //   let pulsarClient = new BasePulsarClient(config);
+
+  //   expect(pulsarClient.settings.path).toBe(config.path);
+  //   expect(pulsarClient.settings.jwtToken).toBe(config.jwtToken);
+  //   expect(pulsarClient.settings.tlsAllowInsecureConnection).toBe(config.tlsAllowInsecureConnection);
+  // });
+
   it("Configures a pulsarClient properly", async () => {
     let config = {};
     config.path = "pulsar://localhost:1000";
-    config.jwtToken = "1234abcd";
     config.tlsAllowInsecureConnection = true;
 
 
     let pulsarClient = new BasePulsarClient(config);
 
     expect(pulsarClient.settings.path).toBe(config.path);
-    expect(pulsarClient.settings.jwtToken).toBe(config.jwtToken);
     expect(pulsarClient.settings.tlsAllowInsecureConnection).toBe(config.tlsAllowInsecureConnection);
   });
 
 
-  it("Creates a Client properly with JWT", async () => {
+  // it("Creates a Client properly with JWT", async () => {
+  //   let config = {};
+  //   config.path = "pulsar://localhost:1000";
+  //   config.jwtToken = "1234abcd";
+
+
+  //   let pulsarClient = new BasePulsarClient(config);
+
+  //   await pulsarClient.connect();
+  //   expect(pulsarClient.client).toBeTruthy();
+  // });
+
+  it("Creates a Client properly with OAuth2", async () => {
     let config = {};
     config.path = "pulsar://localhost:1000";
-    config.jwtToken = "1234abcd";
-
+    config.client_id = "1234abcd";
+    config.client_secret = "abcd1234";
+    config.issuer_url = "https://accounts.google.com";
+    config.grant_type = "client_credentials";
 
     let pulsarClient = new BasePulsarClient(config);
 
     await pulsarClient.connect();
     expect(pulsarClient.client).toBeTruthy();
   });
+
 
   it("Creates a Client properly without JWT", async () => {
     let config = {};

--- a/src/core/io/Messaging/BasePulsarClient.test.js
+++ b/src/core/io/Messaging/BasePulsarClient.test.js
@@ -25,20 +25,6 @@ it("Doesn't Error on empty config", async () => {
     expect(pulsarClient.settings.tlsAllowInsecureConnection).toBe(config.tlsAllowInsecureConnection);
   });
 
-  // it("Configures a pulsarClient properly", async () => {
-  //   let config = {};
-  //   config.path = "pulsar://localhost:1000";
-  //   config.jwtToken = "1234abcd";
-  //   config.tlsAllowInsecureConnection = true;
-
-
-  //   let pulsarClient = new BasePulsarClient(config);
-
-  //   expect(pulsarClient.settings.path).toBe(config.path);
-  //   expect(pulsarClient.settings.jwtToken).toBe(config.jwtToken);
-  //   expect(pulsarClient.settings.tlsAllowInsecureConnection).toBe(config.tlsAllowInsecureConnection);
-  // });
-
   it("Configures a pulsarClient properly", async () => {
     let config = {};
     config.path = "pulsar://localhost:1000";
@@ -50,19 +36,6 @@ it("Doesn't Error on empty config", async () => {
     expect(pulsarClient.settings.path).toBe(config.path);
     expect(pulsarClient.settings.tlsAllowInsecureConnection).toBe(config.tlsAllowInsecureConnection);
   });
-
-
-  // it("Creates a Client properly with JWT", async () => {
-  //   let config = {};
-  //   config.path = "pulsar://localhost:1000";
-  //   config.jwtToken = "1234abcd";
-
-
-  //   let pulsarClient = new BasePulsarClient(config);
-
-  //   await pulsarClient.connect();
-  //   expect(pulsarClient.client).toBeTruthy();
-  // });
 
   it("Creates a Client properly with OAuth2", async () => {
     let config = {};


### PR DESCRIPTION
BasicPulsarClient creates a consumer with OAuth2 authentication instead of jwt. Config now requires the client_id, client_secret, grant_type, and issuer_id in addition.